### PR TITLE
Support sidebar titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,21 @@ module.exports = {
 Pour plus de détails, reportez-vous à [la documentation de VuePress](https://vuepress.vuejs.org/theme/using-a-theme.html).
 
 ## Configuration
-Le thème ne dispose pas d'éléments de configuration.
+
+### Titres de sections
+Lorsque votre documentation comporte plusieurs dossiers, il est possible de faire apparaitre un titre de section lorsque vous vous trouvez dans un dossier.
+
+Dans votre fichier de configuration VuePress (probablement `.vuepress/config.js`), ajoutez ceci :
+```javascript
+module.exports = {
+  themeConfig: {
+    sidebarTitles: {
+        '/qualite/': "Préparer les données",
+        '/juridique/': "Identifier les données à ouvrir",
+    }
+  }
+}
+```
 
 ## Composants
 Les composants suivants sont disponibles. Ils sont tous indépendants les uns des autres et leur utilisation est optionnelle.

--- a/layouts/Layout.vue
+++ b/layouts/Layout.vue
@@ -1,0 +1,34 @@
+<template>
+  <ParentLayout>
+    <template #sidebar-top v-if="sidebarTitle">
+      <h2 class="sidebar-title" v-text="sidebarTitle" />
+    </template>
+  </ParentLayout>
+</template>
+
+<script>
+import ParentLayout from '@parent-theme/layouts/Layout.vue'
+
+export default {
+  name: 'Layout',
+  components: {
+    ParentLayout,
+  },
+  computed: {
+    sidebarTitle: function () {
+      for (let [group, title] of Object.entries(this.$site.themeConfig.sidebarTitles || {})) {
+        if (this.$page.path.startsWith(group)) {
+          return title
+        }
+      }
+      return null
+    }
+  }
+}
+</script>
+<style lang="stylus">
+.sidebar-title {
+  padding-left 1.25rem
+  padding-bottom 0
+}
+</style>

--- a/layouts/Layout.vue
+++ b/layouts/Layout.vue
@@ -21,7 +21,6 @@ export default {
           return title
         }
       }
-      return null
     }
   }
 }

--- a/layouts/Layout.vue
+++ b/layouts/Layout.vue
@@ -27,8 +27,7 @@ export default {
 }
 </script>
 <style lang="stylus">
-.sidebar-title {
+.sidebar-title
   padding-left 1.25rem
   padding-bottom 0
-}
 </style>

--- a/layouts/Layout.vue
+++ b/layouts/Layout.vue
@@ -15,7 +15,7 @@ export default {
     ParentLayout,
   },
   computed: {
-    sidebarTitle: function () {
+    sidebarTitle: () => {
       for (let [group, title] of Object.entries(this.$site.themeConfig.sidebarTitles || {})) {
         if (this.$page.path.startsWith(group)) {
           return title


### PR DESCRIPTION
Provide a way to add sidebar titles for groups through configuration in `.vuepress/config.js`.

```
sidebarTitles: {
  '/qualite/': 'Name of group'
}
```
![image](https://user-images.githubusercontent.com/295709/71418487-fd859380-266a-11ea-836b-1174dc579140.png)

Unfortunately we can't use it yet. A fix has been pushed in https://github.com/vuejs/vuepress/pull/1951 but it's not released yet https://github.com/vuejs/vuepress/issues/2054